### PR TITLE
Enable setting Discoverable for peripherals

### DIFF
--- a/binc/adapter.c
+++ b/binc/adapter.c
@@ -872,6 +872,19 @@ void binc_adapter_power_off(Adapter *adapter) {
     adapter_set_property(adapter, ADAPTER_PROPERTY_POWERED, g_variant_new("b", FALSE));
 }
 
+void binc_adapter_discoverable_on(Adapter *adapter) {
+    g_assert(adapter != NULL);
+
+    adapter_set_property(adapter, ADAPTER_PROPERTY_DISCOVERABLE, g_variant_new("b", TRUE));
+}
+
+void binc_adapter_discoverable_off(Adapter *adapter) {
+    g_assert(adapter != NULL);
+
+    adapter_set_property(adapter, ADAPTER_PROPERTY_DISCOVERABLE, g_variant_new("b", FALSE));
+}
+
+
 void binc_adapter_set_discovery_cb(Adapter *adapter, AdapterDiscoveryResultCallback callback) {
     g_assert(adapter != NULL);
     g_assert(callback != NULL);

--- a/binc/adapter.h
+++ b/binc/adapter.h
@@ -72,6 +72,10 @@ void binc_adapter_power_on(Adapter *adapter);
 
 void binc_adapter_power_off(Adapter *adapter);
 
+void binc_adapter_discoverable_on(Adapter *adapter);
+
+void binc_adapter_discoverable_off(Adapter *adapter);
+
 const char *binc_adapter_get_path(const Adapter *adapter);
 
 const char *binc_adapter_get_name(const Adapter *adapter);


### PR DESCRIPTION
Without this functionality I wasn't able to see the peripheral in a list of bluetooth devices - very new to this repository so apologies if I've made a redundancy