### PR TITLE
Include errno.h for EINVAL

### DIFF
--- a/binc/agent.c
+++ b/binc/agent.c
@@ -26,6 +26,7 @@
 #include "device.h"
 #include "device_internal.h"
 #include "logger.h"
+#include <errno.h>
 #include <glib.h>
 #include <stdio.h>
 

--- a/binc/application.c
+++ b/binc/application.c
@@ -26,6 +26,7 @@
 #include "logger.h"
 #include "characteristic.h"
 #include "utility.h"
+#include <errno.h>
 
 #define GATT_SERV_INTERFACE "org.bluez.GattService1"
 #define GATT_CHAR_INTERFACE "org.bluez.GattCharacteristic1"


### PR DESCRIPTION
Got build errors of the sort:
`
error: ‘EINVAL’ undeclared (first use in this function)
`
Hence including `errno.h` in a couple of places.