### PR TITLE
add a build check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,11 @@
+on: pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+       - uses: actions/checkout@v4
+       - name: Build
+         run: |
+           cmake .
+           cmake --build .


### PR DESCRIPTION
This PR sets up a very simple and basic build check any time a PR is created or pushed-to. If you'd like to take it, you can give it teeth by setting up `build` as a required check for PR merging, or you can just use it as an indicator, or you can ignore it entirely :)

Since this project is a small open-source library,  you might consider setting the option that lets any inbound pull requests automatically run the action. Otherwise, if you do want checks, you'll need to hand-approve every single CI run of every single PR update... which I can confirm is not a great time!