### PR TITLE
Add user_data to Adapter and Device

### DIFF
--- a/binc/adapter.c
+++ b/binc/adapter.c
@@ -88,6 +88,7 @@ struct binc_adapter {
     AdapterDiscoveryStateChangeCallback discoveryStateCallback;
     AdapterPoweredStateChangeCallback poweredStateCallback;
     RemoteCentralConnectionStateCallback centralStateCallback;
+    void *user_data; // Borrowed
     GHashTable *devices_cache; // Owned
 
     Advertisement *advertisement; // Borrowed
@@ -530,6 +531,7 @@ static Adapter *binc_adapter_create(GDBusConnection *connection, const char *pat
     adapter->discovery_filter.rssi = -255;
     adapter->devices_cache = g_hash_table_new_full(g_str_hash, g_str_equal,
                                                    g_free, (GDestroyNotify) binc_device_free);
+    adapter->user_data = NULL;
     setup_signal_subscribers(adapter);
     return adapter;
 }
@@ -1122,4 +1124,14 @@ void binc_adapter_unregister_application(Adapter *adapter, Application *applicat
 void binc_adapter_set_remote_central_cb(Adapter *adapter, RemoteCentralConnectionStateCallback callback) {
     g_assert(adapter != NULL);
     adapter->centralStateCallback = callback;
+}
+
+void binc_adapter_set_user_data(Adapter *adapter, void *user_data) {
+    g_assert(adapter != NULL);
+    adapter->user_data = user_data;
+}
+
+void *binc_adapter_get_user_data(const Adapter *adapter) {
+    g_assert(adapter != NULL);
+    return adapter->user_data;
 }

--- a/binc/adapter.h
+++ b/binc/adapter.h
@@ -108,6 +108,10 @@ void binc_adapter_unregister_application(Adapter *adapter, Application *applicat
 
 void binc_adapter_set_remote_central_cb(Adapter *adapter, RemoteCentralConnectionStateCallback callback);
 
+void binc_adapter_set_user_data(Adapter *adapter, void *user_data);
+
+void *binc_adapter_get_user_data(const Adapter *adapter);
+
 #ifdef __cplusplus
 }
 #endif

--- a/binc/device.c
+++ b/binc/device.c
@@ -100,6 +100,7 @@ struct binc_device {
     OnNotifyingStateChangedCallback on_notify_state_callback;
     OnDescReadCallback on_read_desc_cb;
     OnDescWriteCallback on_write_desc_cb;
+    void  *user_data; // Borrowed
 };
 
 
@@ -117,6 +118,7 @@ Device *binc_device_create(const char *path, Adapter *adapter) {
     device->rssi = -255;
     device->txpower = -255;
     device->mtu = 23;
+    device->user_data = NULL;
     return device;
 }
 
@@ -1194,3 +1196,14 @@ void binc_internal_device_update_property(Device *device, const char *property_n
         g_variant_iter_free(iter);
     }
 }
+
+void binc_device_set_user_data(Device *device, void *user_data) {
+    g_assert(device != NULL);
+    device->user_data = user_data;
+}
+
+void *binc_device_get_user_data(const Device *device) {
+    g_assert(device != NULL);
+    return device->user_data;
+}
+

--- a/binc/device.c
+++ b/binc/device.c
@@ -100,7 +100,7 @@ struct binc_device {
     OnNotifyingStateChangedCallback on_notify_state_callback;
     OnDescReadCallback on_read_desc_cb;
     OnDescWriteCallback on_write_desc_cb;
-    void  *user_data; // Borrowed
+    void *user_data; // Borrowed
 };
 
 

--- a/binc/device.h
+++ b/binc/device.h
@@ -139,6 +139,10 @@ gboolean binc_device_is_central(const Device *device);
 
 char *binc_device_to_string(const Device *device);
 
+void binc_device_set_user_data(Device *device, void *user_data);
+
+void *binc_device_get_user_data(const Device *device);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This PR adds a new non-owned `user_data` field to both `Adapter` and `Device`, which allows users to store application context inside of these primitives. Without this, applications need to keep their own external data structures that map `Adapter` and `Device` to the application context, for lookup inside of `bluez_inc` callbacks that only provide `Adapter *` and/or `Device *`.
