### PR TITLE
`BINC_` enum name prefixes

### DIFF
--- a/binc/adapter.c
+++ b/binc/adapter.c
@@ -261,7 +261,7 @@ static void deliver_discovery_result(Adapter *adapter, Device *device) {
     g_assert(adapter != NULL);
     g_assert(device != NULL);
 
-    if (binc_device_get_connection_state(device) == DISCONNECTED) {
+    if (binc_device_get_connection_state(device) == BINC_DISCONNECTED) {
         // Double check if the device matches the discovery filter
         if (!matches_discovery_filter(adapter, device)) return;
 
@@ -335,11 +335,11 @@ static void binc_internal_device_appeared(__attribute__((unused)) GDBusConnectio
                                 g_strdup(binc_device_get_path(device)),
                                 device);
 
-            if (adapter->discovery_state == BINC_DISCOVERY_STARTED && binc_device_get_connection_state(device) == DISCONNECTED) {
+            if (adapter->discovery_state == BINC_DISCOVERY_STARTED && binc_device_get_connection_state(device) == BINC_DISCONNECTED) {
                 deliver_discovery_result(adapter, device);
             }
 
-            if (binc_device_get_connection_state(device) == CONNECTED &&
+            if (binc_device_get_connection_state(device) == BINC_CONNECTED &&
                 binc_device_get_rssi(device) == -255 &&
                 binc_device_get_uuids(device) == NULL) {
                 binc_device_set_is_central(device, TRUE);
@@ -785,7 +785,7 @@ GList *binc_adapter_get_connected_devices(const Adapter *adapter) {
     GList *result = NULL;
     for (GList *iterator = all_devices; iterator; iterator = iterator->next) {
         Device *device = (Device *) iterator->data;
-        if (binc_device_get_connection_state(device) == CONNECTED) {
+        if (binc_device_get_connection_state(device) == BINC_CONNECTED) {
             result = g_list_append(result, device);
         }
     }

--- a/binc/adapter.c
+++ b/binc/adapter.c
@@ -57,10 +57,10 @@ static const char *const SIGNAL_PROPERTIES_CHANGED = "PropertiesChanged";
 static const guint MAC_ADDRESS_LENGTH = 17;
 
 static const char *discovery_state_names[] = {
-        [STOPPED] = "stopped",
-        [STARTED] = "started",
-        [STARTING]  = "starting",
-        [STOPPING]  = "stopping"
+        [BINC_DISCOVERY_STOPPED] = "stopped",
+        [BINC_DISCOVERY_STARTED] = "started",
+        [BINC_DISCOVERY_STARTING]  = "starting",
+        [BINC_DISCOVERY_STOPPING]  = "stopping"
 };
 
 typedef struct binc_discovery_filter {
@@ -335,7 +335,7 @@ static void binc_internal_device_appeared(__attribute__((unused)) GDBusConnectio
                                 g_strdup(binc_device_get_path(device)),
                                 device);
 
-            if (adapter->discovery_state == STARTED && binc_device_get_connection_state(device) == DISCONNECTED) {
+            if (adapter->discovery_state == BINC_DISCOVERY_STARTED && binc_device_get_connection_state(device) == DISCONNECTED) {
                 deliver_discovery_result(adapter, device);
             }
 
@@ -438,11 +438,11 @@ static void binc_internal_device_changed(__attribute__((unused)) GDBusConnection
                 isDiscoveryResult = TRUE;
             }
         }
-        if (adapter->discovery_state == STARTED && isDiscoveryResult) {
+        if (adapter->discovery_state == BINC_DISCOVERY_STARTED && isDiscoveryResult) {
             deliver_discovery_result(adapter, device);
         }
 
-        if (binc_device_get_bonding_state(device) ==  BONDED && binc_device_get_rssi(device) == -255) {
+        if (binc_device_get_bonding_state(device) == BONDED && binc_device_get_rssi(device) == -255) {
             binc_device_set_is_central(device, TRUE);
         }
 
@@ -684,13 +684,13 @@ static void binc_internal_start_discovery_cb(__attribute__((unused)) GObject *so
 
     if (error != NULL) {
         log_debug(TAG, "failed to call '%s' (error %d: %s)", METHOD_START_DISCOVERY, error->code, error->message);
-        adapter->discovery_state = STOPPED;
+        adapter->discovery_state = BINC_DISCOVERY_STOPPED;
         if (adapter->discoveryStateCallback != NULL) {
             adapter->discoveryStateCallback(adapter, adapter->discovery_state, error);
         }
         g_clear_error(&error);
     } else {
-        binc_internal_set_discovery_state(adapter, STARTED);
+        binc_internal_set_discovery_state(adapter, BINC_DISCOVERY_STARTED);
     }
 
     if (value != NULL) {
@@ -701,8 +701,8 @@ static void binc_internal_start_discovery_cb(__attribute__((unused)) GObject *so
 void binc_adapter_start_discovery(Adapter *adapter) {
     g_assert (adapter != NULL);
 
-    if (adapter->discovery_state == STOPPED) {
-        binc_internal_set_discovery_state(adapter, STARTING);
+    if (adapter->discovery_state == BINC_DISCOVERY_STOPPED) {
+        binc_internal_set_discovery_state(adapter, BINC_DISCOVERY_STARTING);
         g_dbus_connection_call(adapter->connection,
                                BLUEZ_DBUS,
                                adapter->path,
@@ -734,7 +734,7 @@ static void binc_internal_stop_discovery_cb(__attribute__((unused)) GObject *sou
         }
         g_clear_error(&error);
     } else {
-        binc_internal_set_discovery_state(adapter, STOPPED);
+        binc_internal_set_discovery_state(adapter, BINC_DISCOVERY_STOPPED);
     }
 
     if (value != NULL)
@@ -744,8 +744,8 @@ static void binc_internal_stop_discovery_cb(__attribute__((unused)) GObject *sou
 void binc_adapter_stop_discovery(Adapter *adapter) {
     g_assert (adapter != NULL);
 
-    if (adapter->discovery_state == STARTED) {
-        binc_internal_set_discovery_state(adapter, STOPPING);
+    if (adapter->discovery_state == BINC_DISCOVERY_STARTED) {
+        binc_internal_set_discovery_state(adapter, BINC_DISCOVERY_STOPPING);
         g_dbus_connection_call(adapter->connection,
                                BLUEZ_DBUS,
                                adapter->path,

--- a/binc/adapter.c
+++ b/binc/adapter.c
@@ -442,7 +442,7 @@ static void binc_internal_device_changed(__attribute__((unused)) GDBusConnection
             deliver_discovery_result(adapter, device);
         }
 
-        if (binc_device_get_bonding_state(device) == BONDED && binc_device_get_rssi(device) == -255) {
+        if (binc_device_get_bonding_state(device) == BINC_BONDED && binc_device_get_rssi(device) == -255) {
             binc_device_set_is_central(device, TRUE);
         }
 

--- a/binc/adapter.h
+++ b/binc/adapter.h
@@ -32,7 +32,7 @@ extern "C" {
 #endif
 
 typedef enum DiscoveryState {
-    STOPPED = 0, STARTED = 1, STARTING = 2, STOPPING = 3
+    BINC_DISCOVERY_STOPPED = 0, BINC_DISCOVERY_STARTED = 1, BINC_DISCOVERY_STARTING = 2, BINC_DISCOVERY_STOPPING = 3
 } DiscoveryState;
 
 typedef void (*AdapterDiscoveryResultCallback)(Adapter *adapter, Device *device);

--- a/binc/agent.c
+++ b/binc/agent.c
@@ -98,7 +98,7 @@ static void bluez_agent_method_call(GDBusConnection *conn,
         g_free(object_path);
 
         if (device != NULL) {
-            binc_device_set_bonding_state(device, BONDING);
+            binc_device_set_bonding_state(device, BINC_BONDING);
         }
 
         if (agent->request_passkey_callback != NULL) {
@@ -123,7 +123,7 @@ static void bluez_agent_method_call(GDBusConnection *conn,
         Device *device = binc_adapter_get_device_by_path(adapter, object_path);
         g_free(object_path);
         if (device != NULL) {
-            binc_device_set_bonding_state(device, BONDING);
+            binc_device_set_bonding_state(device, BINC_BONDING);
         }
         if (agent->request_authorization_callback != NULL) {
             gboolean allowed = agent->request_authorization_callback(device);

--- a/binc/device.c
+++ b/binc/device.c
@@ -57,10 +57,10 @@ static const char *const INTERFACE_CHARACTERISTIC = "org.bluez.GattCharacteristi
 static const char *const INTERFACE_DESCRIPTOR = "org.bluez.GattDescriptor1";
 
 static const char *connection_state_names[] = {
-        [DISCONNECTED] = "DISCONNECTED",
-        [CONNECTED] = "CONNECTED",
-        [CONNECTING]  = "CONNECTING",
-        [DISCONNECTING]  = "DISCONNECTING"
+        [BINC_DISCONNECTED] = "DISCONNECTED",
+        [BINC_CONNECTED] = "CONNECTED",
+        [BINC_CONNECTING]  = "CONNECTING",
+        [BINC_DISCONNECTING]  = "DISCONNECTING"
 };
 
 struct binc_device {
@@ -114,7 +114,7 @@ Device *binc_device_create(const char *path, Adapter *adapter) {
     device->adapter = adapter;
     device->connection = binc_adapter_get_dbus_connection(adapter);
     device->bondingState = BOND_NONE;
-    device->connection_state = DISCONNECTED;
+    device->connection_state = BINC_DISCONNECTED;
     device->rssi = -255;
     device->txpower = -255;
     device->mtu = 23;
@@ -574,7 +574,7 @@ static void binc_device_changed(__attribute__((unused)) GDBusConnection *conn,
     while (g_variant_iter_loop(properties_changed, "{&sv}", &property_name, &property_value)) {
         if (g_str_equal(property_name, DEVICE_PROPERTY_CONNECTED)) {
             binc_device_internal_set_conn_state(device, g_variant_get_boolean(property_value), NULL);
-            if (device->connection_state == DISCONNECTED) {
+            if (device->connection_state == BINC_DISCONNECTED) {
                 g_dbus_connection_signal_unsubscribe(device->connection, device->device_prop_changed);
                 device->device_prop_changed = 0;
             }
@@ -585,8 +585,8 @@ static void binc_device_changed(__attribute__((unused)) GDBusConnection *conn,
                 binc_collect_gatt_tree(device);
             }
 
-            if (device->services_resolved == FALSE && device->connection_state == CONNECTED) {
-                binc_device_internal_set_conn_state(device, DISCONNECTING, NULL);
+            if (device->services_resolved == FALSE && device->connection_state == BINC_CONNECTED) {
+                binc_device_internal_set_conn_state(device, BINC_DISCONNECTING, NULL);
             }
         } else if (g_str_equal(property_name, DEVICE_PROPERTY_PAIRED)) {
             device->paired = g_variant_get_boolean(property_value);
@@ -625,7 +625,7 @@ static void binc_internal_device_connect_cb(__attribute__((unused)) GObject *sou
 
         // Maybe don't do this because connection changes may com later? See A&D scale testing
         // Or send the current connection state?
-        binc_device_internal_set_conn_state(device, DISCONNECTED, error);
+        binc_device_internal_set_conn_state(device, BINC_DISCONNECTED, error);
 
         g_clear_error(&error);
     }
@@ -651,12 +651,12 @@ void binc_device_connect(Device *device) {
     g_assert(device->path != NULL);
 
     // Don't do anything if we are not disconnected
-    if (device->connection_state != DISCONNECTED) return;
+    if (device->connection_state != BINC_DISCONNECTED) return;
 
     log_debug(TAG, "Connecting to '%s' (%s) (%s)", device->name, device->address,
               device->paired ? "BONDED" : "BOND_NONE");
 
-    binc_device_internal_set_conn_state(device, CONNECTING, NULL);
+    binc_device_internal_set_conn_state(device, BINC_CONNECTING, NULL);
     subscribe_prop_changed(device);
     g_dbus_connection_call(device->connection,
                            BLUEZ_DBUS,
@@ -687,7 +687,7 @@ static void binc_internal_device_pair_cb(__attribute__((unused)) GObject *source
 
     if (error != NULL) {
         log_error(TAG, "failed to call '%s' (error %d: %s)", DEVICE_METHOD_PAIR, error->code, error->message);
-        binc_device_internal_set_conn_state(device, DISCONNECTED, error);
+        binc_device_internal_set_conn_state(device, BINC_DISCONNECTED, error);
         g_clear_error(&error);
     }
 }
@@ -698,12 +698,12 @@ void binc_device_pair(Device *device) {
 
     log_debug(TAG, "pairing device '%s'", device->address);
 
-    if (device->connection_state == DISCONNECTING) {
+    if (device->connection_state == BINC_DISCONNECTING) {
         return;
     }
 
-    if (device->connection_state == DISCONNECTED) {
-        binc_device_internal_set_conn_state(device, CONNECTING, NULL);
+    if (device->connection_state == BINC_DISCONNECTED) {
+        binc_device_internal_set_conn_state(device, BINC_CONNECTING, NULL);
     }
 
     subscribe_prop_changed(device);
@@ -736,7 +736,7 @@ static void binc_internal_device_disconnect_cb(__attribute__((unused)) GObject *
 
     if (error != NULL) {
         log_error(TAG, "failed to call '%s' (error %d: %s)", DEVICE_METHOD_DISCONNECT, error->code, error->message);
-        binc_device_internal_set_conn_state(device, CONNECTED, error);
+        binc_device_internal_set_conn_state(device, BINC_CONNECTED, error);
         g_clear_error(&error);
     }
 }
@@ -746,11 +746,11 @@ void binc_device_disconnect(Device *device) {
     g_assert(device->path != NULL);
 
     // Don't do anything if we are not connected
-    if (device->connection_state != CONNECTED) return;
+    if (device->connection_state != BINC_CONNECTED) return;
 
     log_debug(TAG, "Disconnecting '%s' (%s)", device->name, device->address);
 
-    binc_device_internal_set_conn_state(device, DISCONNECTING, NULL);
+    binc_device_internal_set_conn_state(device, BINC_DISCONNECTING, NULL);
     g_dbus_connection_call(device->connection,
                            BLUEZ_DBUS,
                            device->path,
@@ -1138,7 +1138,7 @@ void binc_internal_device_update_property(Device *device, const char *property_n
     } else if (g_str_equal(property_name, DEVICE_PROPERTY_ALIAS)) {
         binc_device_set_alias(device, g_variant_get_string(property_value, NULL));
     } else if (g_str_equal(property_name, DEVICE_PROPERTY_CONNECTED)) {
-        binc_device_internal_set_conn_state(device, g_variant_get_boolean(property_value) ? CONNECTED : DISCONNECTED,
+        binc_device_internal_set_conn_state(device, g_variant_get_boolean(property_value) ? BINC_CONNECTED : BINC_DISCONNECTED,
                                             NULL);
     } else if (g_str_equal(property_name, DEVICE_PROPERTY_NAME)) {
         binc_device_set_name(device, g_variant_get_string(property_value, NULL));

--- a/binc/device.c
+++ b/binc/device.c
@@ -113,7 +113,7 @@ Device *binc_device_create(const char *path, Adapter *adapter) {
     device->path = g_strdup(path);
     device->adapter = adapter;
     device->connection = binc_adapter_get_dbus_connection(adapter);
-    device->bondingState = BOND_NONE;
+    device->bondingState = BINC_BOND_NONE;
     device->connection_state = BINC_DISCONNECTED;
     device->rssi = -255;
     device->txpower = -255;
@@ -581,7 +581,7 @@ static void binc_device_changed(__attribute__((unused)) GDBusConnection *conn,
         } else if (g_str_equal(property_name, DEVICE_PROPERTY_SERVICES_RESOLVED)) {
             device->services_resolved = g_variant_get_boolean(property_value);
             log_debug(TAG, "ServicesResolved %s", device->services_resolved ? "true" : "false");
-            if (device->services_resolved == TRUE && device->bondingState != BONDING) {
+            if (device->services_resolved == TRUE && device->bondingState != BINC_BONDING) {
                 binc_collect_gatt_tree(device);
             }
 
@@ -591,7 +591,7 @@ static void binc_device_changed(__attribute__((unused)) GDBusConnection *conn,
         } else if (g_str_equal(property_name, DEVICE_PROPERTY_PAIRED)) {
             device->paired = g_variant_get_boolean(property_value);
             log_debug(TAG, "Paired %s", device->paired ? "true" : "false");
-            binc_device_set_bonding_state(device, device->paired ? BONDED : BOND_NONE);
+            binc_device_set_bonding_state(device, device->paired ? BINC_BONDED : BINC_BOND_NONE);
 
             // If gatt-tree has not been built yet, start building it
             if (device->services == NULL && device->services_resolved && !device->service_discovery_started) {
@@ -654,7 +654,7 @@ void binc_device_connect(Device *device) {
     if (device->connection_state != BINC_DISCONNECTED) return;
 
     log_debug(TAG, "Connecting to '%s' (%s) (%s)", device->name, device->address,
-              device->paired ? "BONDED" : "BOND_NONE");
+              device->paired ? "BINC_BONDED" : "BINC_BOND_NONE");
 
     binc_device_internal_set_conn_state(device, BINC_CONNECTING, NULL);
     subscribe_prop_changed(device);
@@ -1017,7 +1017,7 @@ gboolean binc_device_get_paired(const Device *device) {
 void binc_device_set_paired(Device *device, gboolean paired) {
     g_assert(device != NULL);
     device->paired = paired;
-    binc_device_set_bonding_state(device, paired ? BONDED : BOND_NONE);
+    binc_device_set_bonding_state(device, paired ? BINC_BONDED : BINC_BOND_NONE);
 }
 
 short binc_device_get_rssi(const Device *device) {

--- a/binc/device.h
+++ b/binc/device.h
@@ -37,7 +37,7 @@ typedef enum ConnectionState {
 } ConnectionState;
 
 typedef enum BondingState {
-    BOND_NONE = 0, BONDING = 1, BONDED = 2
+    BINC_BOND_NONE = 0, BINC_BONDING = 1, BINC_BONDED = 2
 } BondingState;
 
 typedef void (*ConnectionStateChangedCallback)(Device *device, ConnectionState state, const GError *error);

--- a/binc/device.h
+++ b/binc/device.h
@@ -33,7 +33,7 @@ extern "C" {
 #endif
 
 typedef enum ConnectionState {
-    DISCONNECTED = 0, CONNECTED = 1, CONNECTING = 2, DISCONNECTING = 3
+    BINC_DISCONNECTED = 0, BINC_CONNECTED = 1, BINC_CONNECTING = 2, BINC_DISCONNECTING = 3
 } ConnectionState;
 
 typedef enum BondingState {

--- a/examples/central/main.c
+++ b/examples/central/main.c
@@ -51,9 +51,9 @@ void on_connection_state_changed(Device *device, ConnectionState state, const GE
     log_debug(TAG, "'%s' (%s) state: %s (%d)", binc_device_get_name(device), binc_device_get_address(device),
               binc_device_get_connection_state_name(device), state);
 
-    if (state == DISCONNECTED) {
+    if (state == BINC_DISCONNECTED) {
         // Remove devices immediately of they are not bonded
-        if (binc_device_get_bonding_state(device) != BONDED) {
+        if (binc_device_get_bonding_state(device) != BINC_BONDED) {
             binc_adapter_remove_device(default_adapter, device);
         }
     }

--- a/examples/peripheral/peripheral.c
+++ b/examples/peripheral/peripheral.c
@@ -55,9 +55,9 @@ void on_central_state_changed(Adapter *adapter, Device *device) {
 
     log_debug(TAG, "remote central %s is %s", binc_device_get_address(device), binc_device_get_connection_state_name(device));
     ConnectionState state = binc_device_get_connection_state(device);
-    if (state == CONNECTED) {
+    if (state == BINC_CONNECTED) {
         binc_adapter_stop_advertising(adapter, advertisement);
-    } else if (state == DISCONNECTED){
+    } else if (state == BINC_DISCONNECTED){
         binc_adapter_start_advertising(adapter, advertisement);
     }
 }


### PR DESCRIPTION
This PR simply prefixes the public-header enums with `BINC_`. In the case of discovery, I went with `BINC_DISCOVERY_` because that seemed more explicit than simply having `BINC_STARTED`, `BINC_STOPPED`, etc.. If you prefer that, though, I'm happy to change it.