### PR TITLE
binc_device_stop_notify

### DIFF
--- a/binc/device.c
+++ b/binc/device.c
@@ -921,6 +921,20 @@ gboolean binc_device_start_notify(const Device *device, const char *service_uuid
     return FALSE;
 }
 
+gboolean binc_device_stop_notify(const Device *device, const char *service_uuid, const char *characteristic_uuid) {
+    g_assert(device != NULL);
+    g_assert(is_valid_uuid(service_uuid));
+    g_assert(is_valid_uuid(characteristic_uuid));
+
+    Characteristic *characteristic = binc_device_get_characteristic(device, service_uuid, characteristic_uuid);
+    if (characteristic != NULL && binc_characteristic_supports_notify(characteristic) && binc_characteristic_is_notifying(characteristic)) {
+        binc_characteristic_stop_notify(characteristic);
+        return TRUE;
+    }
+    return FALSE;
+}
+
+
 void binc_device_set_read_desc_cb(Device *device, OnDescReadCallback callback) {
     g_assert(device != NULL);
     g_assert(callback != NULL);

--- a/binc/device.h
+++ b/binc/device.h
@@ -76,6 +76,8 @@ void binc_device_set_notify_state_cb(Device *device, OnNotifyingStateChangedCall
 
 gboolean binc_device_start_notify(const Device *device, const char *service_uuid, const char *characteristic_uuid);
 
+gboolean binc_device_stop_notify(const Device *device, const char *service_uuid, const char *characteristic_uuid);
+
 gboolean binc_device_read_desc(const Device *device, const char *service_uuid,
                                const char *characteristic_uuid, const char *desc_uuid);
 


### PR DESCRIPTION
There exists a function `binc_device_start_notify` but not the equivalent `binc_device_stop_notify`. For users to stop expressing interest in notifications on a specific characteristic, they had to use the functional-but-asymmetrical `binc_characteristic_stop_notify` function.

This PR adds a very simple `binc_device_stop_notify` method, for symmetry.

(If you don't want it, that's cool; the c'stic interface works just fine)