### PR TITLE
add log_set_handler

### DIFF
--- a/binc/logger.h
+++ b/binc/logger.h
@@ -45,6 +45,10 @@ void log_set_level(LogLevel level);
 
 void log_set_filename(const char* filename, long max_size, int max_files);
 
+typedef void (*LogEventCallback)(LogLevel level, const char *tag, const char *message);
+
+void log_set_handler(LogEventCallback callback);
+
 void log_enabled(gboolean enabled);
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR addresses https://github.com/weliem/bluez_inc/issues/28 by adding a new function `log_set_handler`, which takes a callback. If this is set, none of the existing log functionality is engaged- only the callback is called. The callback can be set to and from `NULL` dynamically and the built-in log flow will be redirected or resumed.