### PR TITLE
update project name + docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(test C)
+project(bluez_inc C)
 
 set(CMAKE_C_STANDARD 99)
 
@@ -13,4 +13,3 @@ include_directories(${GLIB_INCLUDE_DIRS})
 add_subdirectory(binc)
 add_subdirectory(examples/central)
 add_subdirectory(examples/peripheral)
-

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ void on_connection_state_changed(Device *device, ConnectionState state, GError *
     }
 
     log_debug(TAG, "'%s' (%s) state: %s (%d)", binc_device_get_name(device), binc_device_get_address(device), binc_device_get_connection_state_name(device), state);
-    if (state == DISCONNECTED && binc_device_get_bonding_state(device) != BONDED) {
+    if (state == BINC_DISCONNECTED && binc_device_get_bonding_state(device) != BINC_BONDED) {
         binc_adapter_remove_device(default_adapter, device);
     }
 }


### PR DESCRIPTION
This PR updates the documentation to the new enum names, and changes the cmake project name from `test` to `bluez_inc`. The project name doesn't really matter that much but I noticed it so I figured I'd update it.