### PR TITLE
Updated parser float functions

### DIFF
--- a/binc/parser.c
+++ b/binc/parser.c
@@ -25,11 +25,24 @@
 #include "math.h"
 #include <time.h>
 
+// IEEE 11073 Reserved float values
+typedef enum {
+    MDER_POSITIVE_INFINITY = 0x007FFFFE,
+    MDER_NaN = 0x007FFFFF,
+    MDER_NRes = 0x00800000,
+    MDER_RESERVED_VALUE = 0x00800001,
+    MDER_NEGATIVE_INFINITY = 0x00800002
+} ReservedFloatValues;
+
 struct parser_instance {
     const GByteArray *bytes;
     guint offset;
     int byteOrder;
 };
+
+static const double reserved_float_values[5] = {MDER_POSITIVE_INFINITY, MDER_NaN, MDER_NaN, MDER_NaN,
+                                                MDER_NEGATIVE_INFINITY};
+
 
 #define BINARY32_MASK_SIGN 0x80000000
 #define BINARY32_MASK_EXPO 0x7FE00000
@@ -165,6 +178,27 @@ double parser_get_float(Parser *parser) {
     g_assert(parser != NULL);
     guint32 int_data = parser_get_uint32(parser);
 
+    guint32 mantissa = int_data & 0xFFFFFF;
+    gint8 exponent = int_data >> 24;
+    double output = 0;
+
+    if (mantissa >= MDER_POSITIVE_INFINITY &&
+        mantissa <= MDER_NEGATIVE_INFINITY) {
+        output = reserved_float_values[mantissa - MDER_POSITIVE_INFINITY];
+    } else {
+        if (mantissa >= 0x800000) {
+            mantissa = -((0xFFFFFF + 1) - mantissa);
+        }
+        output = (mantissa * pow(10.0f, exponent));
+    }
+
+    return output;
+}
+
+double parser_get_754float(Parser *parser) {
+    g_assert(parser != NULL);
+    guint32 int_data = parser_get_uint32(parser);
+
     // Break up into 3 parts
     gboolean sign = int_data & BINARY32_MASK_SIGN;
     guint32 biased_expo = (int_data & BINARY32_MASK_EXPO) >> BINARY32_SHIFT_EXPO;
@@ -193,7 +227,7 @@ double parser_get_float(Parser *parser) {
     return result;
 }
 
-double parser_get_halffloat(Parser *parser) {
+double parser_get_754half(Parser *parser) {
     g_assert(parser != NULL);
     g_assert(parser->offset < parser->bytes->len);
 

--- a/binc/parser.h
+++ b/binc/parser.h
@@ -62,6 +62,8 @@ double parser_get_sfloat(Parser *parser);
 
 double parser_get_float(Parser *parser);
 
+double parser_get_halffloat(Parser *parser);
+
 GDateTime* parser_get_date_time(Parser *parser);
 
 GByteArray* binc_get_date_time();

--- a/binc/parser.h
+++ b/binc/parser.h
@@ -62,7 +62,9 @@ double parser_get_sfloat(Parser *parser);
 
 double parser_get_float(Parser *parser);
 
-double parser_get_halffloat(Parser *parser);
+double parser_get_754half(Parser *parser);
+
+double parser_get_754float(Parser *parser);
 
 GDateTime* parser_get_date_time(Parser *parser);
 


### PR DESCRIPTION
With the parser_get_float function that was there, I was not getting the correct results.  I wasn't sure where the error is, but the results I was getting were way off.  I have updated it to a function that I know works.

I also added a function called "parser_get_halffloat" which will convert the IEEE-754 16-bit version of float.  This is the one with a sign bit, 5-bit exponent, and 10-bit significant.

Both have been tested.