### PR TITLE
Add binc_adapter_get_advertisement

### DIFF
--- a/binc/adapter.c
+++ b/binc/adapter.c
@@ -973,6 +973,11 @@ const char *binc_adapter_get_discovery_state_name(const Adapter *adapter) {
     return discovery_state_names[adapter->discovery_state];
 }
 
+Advertisement *binc_adapter_get_advertisement(const Adapter *adapter) {
+    g_assert(adapter != NULL);
+	return adapter->advertisement;
+}
+
 static void binc_internal_start_advertising_cb(__attribute__((unused)) GObject *source_object,
                                                GAsyncResult *res,
                                                gpointer user_data) {

--- a/binc/adapter.h
+++ b/binc/adapter.h
@@ -88,6 +88,8 @@ const char *binc_adapter_get_discovery_state_name(const Adapter *adapter);
 
 gboolean binc_adapter_get_powered_state(const Adapter *adapter);
 
+Advertisement *binc_adapter_get_advertisement(const Adapter *adapter);
+
 void binc_adapter_set_discovery_cb(Adapter *adapter, AdapterDiscoveryResultCallback callback);
 
 void binc_adapter_set_discovery_state_cb(Adapter *adapter, AdapterDiscoveryStateChangeCallback callback);


### PR DESCRIPTION
Expose advertisement member in Adapter.

Example from peripheral.c

In 'void on_central_state_changed(Adapter *adapter, Device *device) {...}

OLD `binc_adapter_stop_advertising(adapter, advertisement);'
NEW 'binc_adapter_stop_advertising(adapter, adapter->advertisement);

to eliminate use of global Advertisement *advertisement yet still allow changing advertisement if desired.