### PR TITLE
Add device removal callback for adapter

### DIFF
--- a/binc/adapter.h
+++ b/binc/adapter.h
@@ -37,6 +37,8 @@ typedef enum DiscoveryState {
 
 typedef void (*AdapterDiscoveryResultCallback)(Adapter *adapter, Device *device);
 
+typedef void (*AdapterDeviceRemovalCallback)(Adapter *adapter, Device *device);
+
 typedef void (*AdapterDiscoveryStateChangeCallback)(Adapter *adapter, DiscoveryState state, const GError *error);
 
 typedef void (*AdapterPoweredStateChangeCallback)(Adapter *adapter, gboolean state);
@@ -91,6 +93,8 @@ gboolean binc_adapter_get_powered_state(const Adapter *adapter);
 Advertisement *binc_adapter_get_advertisement(const Adapter *adapter);
 
 void binc_adapter_set_discovery_cb(Adapter *adapter, AdapterDiscoveryResultCallback callback);
+
+void binc_adapter_set_device_removal_cb(Adapter *adapter, AdapterDeviceRemovalCallback callback);
 
 void binc_adapter_set_discovery_state_cb(Adapter *adapter, AdapterDiscoveryStateChangeCallback callback);
 


### PR DESCRIPTION
I added device removal callback for adapter in order to ease user space programs to cleanup some sort of information.

I actively used this thing in my own bluetooth app and it worked perfectly without any errors