### PR TITLE
Add binc_application_get_adapter, binc_adapter_set/get_alias

### DIFF
--- a/binc/adapter.c
+++ b/binc/adapter.c
@@ -46,6 +46,7 @@ static const char *const ADAPTER_PROPERTY_POWERED = "Powered";
 static const char *const ADAPTER_PROPERTY_DISCOVERING = "Discovering";
 static const char *const ADAPTER_PROPERTY_ADDRESS = "Address";
 static const char *const ADAPTER_PROPERTY_DISCOVERABLE = "Discoverable";
+static const char *const ADAPTER_PROPERTY_ALIAS = "Alias";
 
 static const char *const DEVICE_PROPERTY_RSSI = "RSSI";
 static const char *const DEVICE_PROPERTY_UUIDS = "UUIDs";
@@ -72,6 +73,7 @@ typedef struct binc_discovery_filter {
 struct binc_adapter {
     const char *path; // Owned
     const char *address; // Owned
+    const char *alias;
     gboolean powered;
     gboolean discoverable;
     gboolean discovering;
@@ -557,6 +559,7 @@ static Adapter *binc_adapter_create(GDBusConnection *connection, const char *pat
     Adapter *adapter = g_new0(Adapter, 1);
     adapter->connection = connection;
     adapter->path = g_strdup(path);
+    adapter->alias = NULL;
     adapter->discovery_filter.rssi = -255;
     adapter->devices_cache = g_hash_table_new_full(g_str_hash, g_str_equal,
                                                    g_free, (GDestroyNotify) binc_device_free);
@@ -924,6 +927,20 @@ void binc_adapter_discoverable_off(Adapter *adapter) {
     g_assert(adapter != NULL);
 
     adapter_set_property(adapter, ADAPTER_PROPERTY_DISCOVERABLE, g_variant_new("b", FALSE));
+}
+
+void binc_adapter_set_alias(Adapter *adapter, char *alias) {
+    g_assert(adapter != NULL);
+    g_assert(alias != NULL );
+
+    adapter->alias = alias;
+    adapter_set_property(adapter, ADAPTER_PROPERTY_ALIAS, g_variant_new("s", alias));
+}
+
+const char *binc_adapter_get_alias(Adapter *adapter) {
+    g_assert(adapter != NULL);
+
+	return adapter->alias;
 }
 
 

--- a/binc/adapter.c
+++ b/binc/adapter.c
@@ -943,6 +943,11 @@ const char *binc_adapter_get_alias(Adapter *adapter) {
 	return adapter->alias;
 }
 
+GDBusConnection *binc_adapter_get_connection(Adapter *adapter) {
+    g_assert(adapter != NULL);
+
+	return adapter->connection;
+}
 
 void binc_adapter_set_discovery_cb(Adapter *adapter, AdapterDiscoveryResultCallback callback) {
     g_assert(adapter != NULL);

--- a/binc/adapter.h
+++ b/binc/adapter.h
@@ -45,6 +45,7 @@ typedef void (*AdapterPoweredStateChangeCallback)(Adapter *adapter, gboolean sta
 
 typedef void (*RemoteCentralConnectionStateCallback)(Adapter *adapter, Device *device);
 
+GDBusConnection *binc_adapter_get_connection(Adapter *adapter);
 
 Adapter *binc_adapter_get_default(GDBusConnection *dbusConnection);
 

--- a/binc/adapter.h
+++ b/binc/adapter.h
@@ -78,6 +78,10 @@ void binc_adapter_discoverable_on(Adapter *adapter);
 
 void binc_adapter_discoverable_off(Adapter *adapter);
 
+void binc_adapter_set_alias(Adapter *adapter, char *alias);
+
+const char *binc_adapter_get_alias(Adapter *adapter);
+
 const char *binc_adapter_get_path(const Adapter *adapter);
 
 const char *binc_adapter_get_name(const Adapter *adapter);

--- a/binc/application.c
+++ b/binc/application.c
@@ -108,6 +108,7 @@ static const gchar descriptor_xml[] =
         "</node>";
 
 struct binc_application {
+    const Adapter *adapter;
     char *path;
     guint registration_id;
     GDBusConnection *connection;
@@ -578,6 +579,7 @@ Application *binc_create_application(const Adapter *adapter) {
     Application *application = g_new0(Application, 1);
     application->connection = binc_adapter_get_dbus_connection(adapter);
     application->path = g_strdup_printf("/org/bluez/bincapp_%s_%s", binc_adapter_get_name(adapter), random_str);
+    application->adapter = adapter;
     application->services = g_hash_table_new_full(g_str_hash,
                                                   g_str_equal,
                                                   g_free,
@@ -1211,6 +1213,11 @@ int binc_application_add_characteristic(Application *application, const char *se
 const char *binc_application_get_path(const Application *application) {
     g_assert(application != NULL);
     return application->path;
+}
+
+const Adapter *binc_application_get_adapter(const Application *application) {
+    g_assert(application != NULL);
+    return application->adapter;
 }
 
 void binc_application_set_char_read_cb(Application *application, onLocalCharacteristicRead callback) {

--- a/binc/application.h
+++ b/binc/application.h
@@ -82,6 +82,8 @@ void binc_application_free(Application *application);
 
 const char *binc_application_get_path(const Application *application);
 
+const Adapter *binc_application_get_adapter(const Application *application);
+
 int binc_application_add_service(Application *application, const char *service_uuid);
 
 int binc_application_add_characteristic(Application *application, const char *service_uuid,


### PR DESCRIPTION
Allow using adapter as unique identifier in callbacks with application arguments.