### PR TITLE
Add functions to toggle Pairable attribute.

### DIFF
--- a/binc/adapter.c
+++ b/binc/adapter.c
@@ -46,6 +46,7 @@ static const char *const ADAPTER_PROPERTY_POWERED = "Powered";
 static const char *const ADAPTER_PROPERTY_DISCOVERING = "Discovering";
 static const char *const ADAPTER_PROPERTY_ADDRESS = "Address";
 static const char *const ADAPTER_PROPERTY_DISCOVERABLE = "Discoverable";
+static const char *const ADAPTER_PROPERTY_PAIRABLE = "Pairable";
 static const char *const ADAPTER_PROPERTY_CONNECTABLE = "Connectable";
 static const char *const ADAPTER_PROPERTY_ALIAS = "Alias";
 
@@ -78,6 +79,7 @@ struct binc_adapter {
     gboolean powered;
     gboolean discoverable;
     gboolean connectable;
+    gboolean pairable;
     gboolean discovering;
     DiscoveryState discovery_state;
     DiscoveryFilter discovery_filter;
@@ -239,6 +241,8 @@ static void binc_internal_adapter_changed(__attribute__((unused)) GDBusConnectio
             adapter->discoverable = g_variant_get_boolean(property_value);
         } else if (g_str_equal(property_name, ADAPTER_PROPERTY_CONNECTABLE)) {
             adapter->connectable = g_variant_get_boolean(property_value);
+        } else if (g_str_equal(property_name, ADAPTER_PROPERTY_PAIRABLE)) {
+            adapter->pairable = g_variant_get_boolean(property_value);
         }
     }
 
@@ -644,6 +648,8 @@ GPtrArray *binc_adapter_find_all(GDBusConnection *dbusConnection) {
                             adapter->discoverable = g_variant_get_boolean(property_value);
                         } else if (g_str_equal(property_name, ADAPTER_PROPERTY_CONNECTABLE)) {
                             adapter->connectable = g_variant_get_boolean(property_value);
+                        } else if (g_str_equal(property_name, ADAPTER_PROPERTY_PAIRABLE)) {
+                            adapter->pairable = g_variant_get_boolean(property_value);
                         } else if (g_str_equal(property_name, ADAPTER_PROPERTY_ALIAS)) {
                             adapter->alias = g_strdup(g_variant_get_string(property_value, NULL));
                         }
@@ -942,6 +948,18 @@ void binc_adapter_discoverable_off(Adapter *adapter) {
     adapter_set_property(adapter, ADAPTER_PROPERTY_DISCOVERABLE, g_variant_new("b", FALSE));
 }
 
+void binc_adapter_pairable_on(Adapter *adapter) {
+    g_assert(adapter != NULL);
+
+    adapter_set_property(adapter, ADAPTER_PROPERTY_PAIRABLE, g_variant_new("b", TRUE));
+}
+
+void binc_adapter_pairable_off(Adapter *adapter) {
+    g_assert(adapter != NULL);
+
+    adapter_set_property(adapter, ADAPTER_PROPERTY_PAIRABLE, g_variant_new("b", FALSE));
+}
+
 void binc_adapter_connectable_on(Adapter *adapter) {
     g_assert(adapter != NULL);
 
@@ -1000,6 +1018,11 @@ gboolean binc_adapter_get_powered_state(const Adapter *adapter) {
 gboolean binc_adapter_is_discoverable(const Adapter *adapter) {
     g_assert(adapter != NULL);
     return adapter->discoverable;
+}
+
+gboolean binc_adapter_is_pairable(const Adapter *adapter) {
+    g_assert(adapter != NULL);
+    return adapter->pairable;
 }
 
 gboolean binc_adapter_is_connectable(const Adapter *adapter) {

--- a/binc/adapter.h
+++ b/binc/adapter.h
@@ -78,6 +78,10 @@ void binc_adapter_discoverable_on(Adapter *adapter);
 
 void binc_adapter_discoverable_off(Adapter *adapter);
 
+void binc_adapter_pairable_on(Adapter *adapter);
+
+void binc_adapter_pairable_off(Adapter *adapter);
+
 void binc_adapter_connectable_on(Adapter *adapter);
 
 void binc_adapter_connectable_off(Adapter *adapter);
@@ -109,6 +113,8 @@ void binc_adapter_set_powered_state_cb(Adapter *adapter, AdapterPoweredStateChan
 GDBusConnection *binc_adapter_get_dbus_connection(const Adapter *adapter);
 
 gboolean binc_adapter_is_discoverable(const Adapter *adapter);
+
+gboolean binc_adapter_is_pairable(const Adapter *adapter);
 
 gboolean binc_adapter_is_connectable(const Adapter *adapter);
 


### PR DESCRIPTION
H(o)i!

This adds functions to toggle the [Pairable](https://github.com/bluez/bluez/blob/master/doc/org.bluez.Adapter.rst#boolean-pairable-readwrite-default-true) attribute.

Context; I needed this while [making](https://github.com/iwanders/HomeKitADK_program) a Linux HAL implementation for the HomeKit reference implementation from [apple/HomeKitADK](https://github.com/apple/HomeKitADK). Here the computer acts as a peripheral, which needs to be open to connections, but not require pairing for a connection. Without setting this attribute to false we get a pairing prompt and the commissioning of the HomeKit peripheral fails.