### PR TITLE
Add user data to the application for use in the Characteristic callback

### DIFF
--- a/binc/application.c
+++ b/binc/application.c
@@ -119,6 +119,7 @@ struct binc_application {
     onLocalCharacteristicStopNotify on_char_stop_notify;
     onLocalDescriptorWrite on_desc_write;
     onLocalDescriptorRead on_desc_read;
+    void *user_data; // Borrowed
 };
 
 typedef struct binc_local_service {
@@ -1338,4 +1339,14 @@ gboolean binc_application_char_is_notifying(const Application *application, cons
     }
 
     return characteristic->notifying;
+}
+
+void binc_application_set_user_data(Application *application, void *user_data){
+    g_assert(application != NULL);
+    application->user_data = user_data;
+}
+
+void *binc_application_get_user_data(const Application *application){
+    g_assert(application != NULL);
+    return application->user_data;
 }

--- a/binc/application.h
+++ b/binc/application.h
@@ -119,6 +119,10 @@ int binc_application_notify(const Application *application, const char *service_
 gboolean binc_application_char_is_notifying(const Application *application, const char *service_uuid,
                                             const char *char_uuid);
 
+void binc_application_set_user_data(Application *application, void *user_data);
+
+void *binc_application_get_user_data(const Application *application);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Hello again,

This second PR adds a the ability to store user data in the application itself. The [callbacks](https://github.com/weliem/bluez_inc/blob/821f6d5839f88b708d781330cc0e785ce6ac9f0b/binc/application.h#L43-L76) don't get a context passed to their signature and I didn't see a way to get a type with user data from an `Application`. Providing the ability to store user data in it seems like a good way to avoid needing a singleton.

In my case (see #104), I need to call into another library from the callbacks, and pass some state when doing so. Thanks for this library, it's been pretty easy to use!